### PR TITLE
adding payWallHop plugin

### DIFF
--- a/plugins/payWallHop.py
+++ b/plugins/payWallHop.py
@@ -1,0 +1,7 @@
+import asyncio
+import commands
+
+@commands.registerEventHandler(name="hop")
+saync def hop(triggerMessage)
+  url = triggerMessage.content.split()[1]
+  await triggerMessage.channel.send("https://12ft.io/proxy?ref=&q=" + url)


### PR DESCRIPTION
When !hop is called with an accompanying string, it prepends the 12ft.io proxy to it. This is intended to be used with web articles that have pay walls and circumvents said paywalls.